### PR TITLE
Passing Licensinginfo to job by property setter

### DIFF
--- a/Sources/ListLabel25.pas
+++ b/Sources/ListLabel25.pas
@@ -866,8 +866,15 @@ begin
 end;
 
 procedure TListLabel25.SetLicensingInfo(const Value: String);
+var
+  tmp: PChar;
 begin
+
   FLicensingInfo := Value;
+  tmp := StrNew(PChar(FLicensingInfo));
+  CheckError(LlSetOptionString(CurrentJobHandle, LL_OPTIONSTR_LICENSINGINFO, tmp));
+  StrDispose(tmp);
+
 end;
 
 procedure TListLabel25.SetAutoBoxType(const Value: TLlAutoBoxType);


### PR DESCRIPTION
I noticed when I was in the productive environment, 
the component does not set the licensinginfo to the job.

