### PR TITLE
Make TLlDOMTableLineGroupHeader.GetBreakBefore use the correct ObjectName

### DIFF
--- a/Sources/l28dom.pas
+++ b/Sources/l28dom.pas
@@ -19364,7 +19364,7 @@ begin
   end
   else
   begin
-    baseObj := GetObject('Columns');
+    baseObj := GetObject('PageBreakOptions');
     fBreakBefore := TLlDOMPropertyPageBreakOptions.Create(baseObj);
     baseObj.Free;
     result := fBreakBefore;


### PR DESCRIPTION
TLlDOMTableLineGroupHeader.GetBreakBefore uses 'Columns" as the Object to retrieve, but it should be 'PageBreakOptions'.