### PR TITLE
Add missing dot in DOM property name for KeepTogetherDataLine

### DIFF
--- a/Sources/l28dom.pas
+++ b/Sources/l28dom.pas
@@ -14009,12 +14009,12 @@ end;
 
 function  TLlDOMPropertyDataLinesOptions.GetKeepTogetherDataLine;
 begin
-  result := GetProperty('KeepTogetherDataLine');
+  result := GetProperty('KeepTogether.DataLine');
 end;
 
 procedure TLlDOMPropertyDataLinesOptions.SetKeepTogetherDataLine(const value: TString);
 begin
-  SetProperty('KeepTogetherDataLine', value);
+  SetProperty('KeepTogether.DataLine', value);
 end;
 { TLlDOMPropertyDataLinesOptionsStaticTable }
 


### PR DESCRIPTION
The underlying DOM name for this property needs a dot inside. 

I wonder why this is not realized as a property of the KeepTogether instance in TLlDOMPropertyDataLinesOptions.